### PR TITLE
Change start date to be a value, not an array

### DIFF
--- a/addon/components/histo-slider.js
+++ b/addon/components/histo-slider.js
@@ -98,9 +98,9 @@ export default Ember.Component.extend({
     return (1.0 / data.length);
   }),
 
-  startValue: computed('dataMin', 'dataMax', function() {
-    let min = (get(this, 'dataMin') + get(this, 'dataMax')) / 2;
-    return [min, get(this, 'dataMax')];
+  start: computed('dataMin', 'dataMax', function() {
+    let mean = (get(this, 'dataMin') + get(this, 'dataMax')) / 2;
+    return mean;
   }),
 
   actions: {

--- a/addon/components/histo-slider.js
+++ b/addon/components/histo-slider.js
@@ -100,6 +100,7 @@ export default Ember.Component.extend({
 
   start: computed('dataMin', 'dataMax', function() {
     let mean = (get(this, 'dataMin') + get(this, 'dataMax')) / 2;
+
     return mean;
   }),
 

--- a/addon/templates/components/histo-slider.hbs
+++ b/addon/templates/components/histo-slider.hbs
@@ -10,5 +10,5 @@
     on-start=(action (mut isSliding) true)
     on-end=(action (mut isSliding) false)
     range=range
-    start=(object-at 0 startValue)}}
+    start=start}}
 </div>


### PR DESCRIPTION
`range-slider`'s `start` is simply a numeric value, not an array. This PR is to change our calculation of the start date (when none given) to be simply a number value