### PR TITLE
Fix divide by 0 error when calculating rect height

### DIFF
--- a/addon/components/histo-slider/meta-histogram.js
+++ b/addon/components/histo-slider/meta-histogram.js
@@ -36,12 +36,12 @@ export default Ember.Component.extend({
     let dataMax = Math.max(...data);
     let heights = [];
 
+    if (dataMax == 0) {
+      return Array(data.length).fill(0);
+    }
+
     data.forEach((datum) => {
-      if (dataMax == 0) {
-        heights.push(0)
-      } else {
-        heights.push((datum / dataMax) * histogramHeight);
-      }
+      heights.push((datum / dataMax) * histogramHeight);
     });
 
     return heights;

--- a/addon/components/histo-slider/meta-histogram.js
+++ b/addon/components/histo-slider/meta-histogram.js
@@ -35,9 +35,15 @@ export default Ember.Component.extend({
     let histogramHeight = get(this, 'histogramHeight');
     let dataMax = Math.max(...data);
     let heights = [];
+
     data.forEach((datum) => {
-      heights.push((datum / dataMax) * histogramHeight);
+      if (dataMax == 0) {
+        heights.push(0)
+      } else {
+        heights.push((datum / dataMax) * histogramHeight);
+      }
     });
+
     return heights;
   }),
 


### PR DESCRIPTION
This error familiar? 
![screen shot 2017-07-28 at 1 52 54 pm](https://user-images.githubusercontent.com/4490013/28730005-7f5ab432-739c-11e7-9265-6a28c9aa3c84.png)

Part of the calculation to determine the rectangle height is `datum / dataMax` but the issue is dataMax can be 0 which is causing the NaN error. This PR returns 0 if dataMax is 0