### PR TITLE
Add Y Axis

### DIFF
--- a/addon/components/histo-slider/meta-histogram.js
+++ b/addon/components/histo-slider/meta-histogram.js
@@ -81,14 +81,13 @@ export default Ember.Component.extend({
   }),
 
   histoTransformX: computed('histogramWidth', function(){
-    return get(this, 'histogramWidth') * 0.1;
+    return get(this, 'histogramWidth') * 0.1 + 1;
   }),
 
   scaleLinear: computed('data', function() {
     let data = get(this, 'data');
     let dataMax = Math.max(...data);
-    let range = get(this, 'range');
-    console.log(get(this, 'histogramHeight'));
+
     return scaleLinear().domain([0, dataMax]).range([get(this, 'histogramHeight'), 0]);
   }),
 
@@ -100,7 +99,9 @@ export default Ember.Component.extend({
     let histoTransformX = get(this, 'histoTransformX');
     let histogramWidth = get(this, 'histogramWidth');
 
-    svg.insert('g', ':first-child').attr('transform', `translate(${histogramWidth -1}, 0) scale(1,0.9)`).call(axisLeft(scaleLinear).tickSize(histogramWidth - 20).ticks(3));
+    let axis = svg.insert('g', ':first-child').attr('transform', `translate(${histogramWidth -1}, 0) scale(1,0.9)`).call(axisLeft(scaleLinear).tickSize(histogramWidth - histoTransformX).ticks(3));
+
+    axis.selectAll('path').attr('opacity', '0');
   },
 
   layout

--- a/addon/components/histo-slider/meta-histogram.js
+++ b/addon/components/histo-slider/meta-histogram.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 import { select } from 'd3-selection';
 import layout from '../../templates/components/histo-slider/meta-histogram';
+import { axisLeft } from 'd3-axis';
+import { scaleLinear } from 'd3-scale';
 
 const { get, computed } = Ember;
 
@@ -18,7 +20,7 @@ export default Ember.Component.extend({
   histogramHeight: null,
 
   height: computed('histogramHeight', function(){
-    return get(this, 'histogramHeight') - 10;
+    return get(this, 'histogramHeight');
   }),
 
   uniqueHistoId: computed('uniqueHistoSliderId', function(){
@@ -77,6 +79,29 @@ export default Ember.Component.extend({
 
     return xArray;
   }),
+
+  histoTransformX: computed('histogramWidth', function(){
+    return get(this, 'histogramWidth') * 0.1;
+  }),
+
+  scaleLinear: computed('data', function() {
+    let data = get(this, 'data');
+    let dataMax = Math.max(...data);
+    let range = get(this, 'range');
+    console.log(get(this, 'histogramHeight'));
+    return scaleLinear().domain([0, dataMax]).range([get(this, 'histogramHeight'), 0]);
+  }),
+
+  didInsertElement() {
+    this._super(...arguments);
+
+    let scaleLinear = get(this, 'scaleLinear');
+    let svg = get(this, 'svg');
+    let histoTransformX = get(this, 'histoTransformX');
+    let histogramWidth = get(this, 'histogramWidth');
+
+    svg.insert('g', ':first-child').attr('transform', `translate(${histogramWidth -1}, 0) scale(1,0.9)`).call(axisLeft(scaleLinear).tickSize(histogramWidth - 20).ticks(3));
+  },
 
   layout
 });

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -6,6 +6,10 @@
   fill-opacity: 0.5;
 }
 
+.ember-histo-slider__backing {
+  fill: #fff;
+}
+
 /* second approach */
 
 $padding: 4px;

--- a/addon/templates/components/histo-slider/meta-histogram.hbs
+++ b/addon/templates/components/histo-slider/meta-histogram.hbs
@@ -2,6 +2,11 @@
   {{#each metaData as |bin index|}}
     <g class="bar" transform="translate({{object-at index rectXs}},{{height}}) scale(-1,1)">
       <rect class="
+        ember-histo-slider__backing"
+        transform="rotate(180)"
+        width={{rectWidth}}
+        height="{{object-at index rectHeights}}px"/>
+      <rect class="
         ember-histo-slider__rect
         {{if (lte index currentBinIndex) 'ember-histo-slider__rect--excluded'}}"
         transform="rotate(180)"

--- a/addon/templates/components/histo-slider/meta-histogram.hbs
+++ b/addon/templates/components/histo-slider/meta-histogram.hbs
@@ -1,4 +1,4 @@
-<g transform="scale(1,1)">
+<g transform="scale(0.9,0.9) translate({{histoTransformX}},0)">
   {{#each metaData as |bin index|}}
     <g class="bar" transform="translate({{object-at index rectXs}},{{height}}) scale(-1,1)">
       <rect class="

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -41,6 +41,6 @@
   }
 }
 
-.class1 rect {
+.class1 .ember-histo-slider__rect {
   fill: #ff7700;
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,32 +1,40 @@
-<div style="width: 200px; height: 100px; padding: 30px 10px;">
-  {{histo-slider
+<div style="width: 200px; padding: 30px 10px;">
+  {{#histo-slider
     class="class1"
     metaData=model
+    histogramHeight=100
     range=range
     onUpdate=(action "onUpdate")
     onSet=(action "onSet")}}
-</div>
     UpdateValue: {{updateValue}}
     Set Value: {{setValue}}
+  {{/histo-slider}}
+</div>
 
-<div style="width: 300px; height: 200px;">
-  {{histo-slider
+
+<div style="width: 300px; padding: 20px;">
+  {{#histo-slider
     class="class2"
+    histogramHeight=200
     metaData=model
     range=range2
     onUpdate=(action "onUpdate2")
     onSet=(action "onSet2")}}
-</div>
     UpdateValue: {{updateValue2}}
     Set Value: {{setValue2}}
+  {{/histo-slider}}
+</div>
 
-<div style="width: 300px; height: 100px;">
-  {{histo-slider
+
+<div style="width: 300px; padding: 20px;">
+  {{#histo-slider
     class="class3"
     metaData=model
+    histogramHeight=100
     range=range3
     onUpdate=(action "onUpdate3")
     onSet=(action "onSet3")}}
-</div>
     UpdateValue: {{updateValue3}}
     Set Value: {{setValue3}}
+  {{/histo-slider}}
+</div>


### PR DESCRIPTION
We want the slider to have a Y Axis. To add this but still allow the dev user to specify the width, we need to shrink the histogram to `scale(0.9,0.9)` of the svg to allow an axis to appear on the left.

As the histo-slider increases in size, we are having a few issues around everything lining up perfectly. Future work will be done on this before release.